### PR TITLE
feat: upgrade site with dark mode, skills labels, tagline, and better works cards

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,16 @@
+name: Build Check
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run build

--- a/app/Home.module.css
+++ b/app/Home.module.css
@@ -105,7 +105,7 @@
   letter-spacing: 0.05em;
   margin-top: -1rem;
   margin-bottom: 2rem;
-  animation: fadeSlideIn 0.8s ease both;
+  animation: slideIn 0.8s ease both;
   animation-delay: 0.4s;
 }
 
@@ -122,6 +122,15 @@
   }
   to {
     opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateY(8px);
+  }
+  to {
     transform: translateY(0);
   }
 }

--- a/app/Home.module.css
+++ b/app/Home.module.css
@@ -98,3 +98,30 @@
 .line:last-child {
   text-align: right;
 }
+
+.tagline {
+  font-size: 1.1rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.05em;
+  margin-top: -1rem;
+  margin-bottom: 2rem;
+  animation: fadeSlideIn 0.8s ease both;
+  animation-delay: 0.4s;
+}
+
+.tag {
+  display: inline-block;
+  animation: fadeSlideIn 0.5s ease both;
+  color: var(--color-text-muted);
+}
+
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/app/about/About.module.css
+++ b/app/about/About.module.css
@@ -1,3 +1,8 @@
 .link {
   text-decoration: underline;
+  color: var(--color-accent);
+
+  &:hover {
+    color: var(--color-accent-hover);
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,8 @@ export const metadata: Metadata = {
   title: 'Sergey Baranov | Web Developer',
 };
 
+const taglines = ['React', 'TypeScript', 'Next.js', 'Node.js'];
+
 export default function HomePage(): ReactElement {
   return (
     <div className={styles.root}>
@@ -15,6 +17,14 @@ export default function HomePage(): ReactElement {
         <span className={`${styles.line} ${styles.shadow}`}>Hello</span>
         <span className={`${styles.line} ${styles.shadow}`}>World</span>
       </h1>
+      <p className={styles.tagline}>
+        Web developer crafting with{' '}
+        {taglines.map((tag, i) => (
+          <span key={tag} className={styles.tag} style={{ animationDelay: `${i * 0.15}s` }}>
+            {tag}{i < taglines.length - 1 ? ' · ' : ''}
+          </span>
+        ))}
+      </p>
       <AnimatedLogo />
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,8 @@ export const metadata: Metadata = {
 };
 
 const taglines = ['React', 'TypeScript', 'Next.js', 'Node.js'];
+const taglineDelay = 0.4;
+const tagStagger = 0.15;
 
 export default function HomePage(): ReactElement {
   return (
@@ -20,7 +22,11 @@ export default function HomePage(): ReactElement {
       <p className={styles.tagline}>
         Web developer crafting with{' '}
         {taglines.map((tag, i) => (
-          <span key={tag} className={styles.tag} style={{ animationDelay: `${i * 0.15}s` }}>
+          <span
+            key={tag}
+            className={styles.tag}
+            style={{ animationDelay: `${taglineDelay + i * tagStagger}s` }}
+          >
             {tag}{i < taglines.length - 1 ? ' · ' : ''}
           </span>
         ))}

--- a/app/skills/components/skills/Skills.module.css
+++ b/app/skills/components/skills/Skills.module.css
@@ -1,33 +1,54 @@
 /* The component style is inserted here. */
 .root {
   display: grid;
-  grid-gap: 2cqw;
+  grid-gap: 1.5rem;
   height: 100%;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  align-content: start;
 }
 
 .cell {
-  display: inline-grid;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  position: relative;
-  height: 200px;
-  margin-bottom: 0.5rem;
+  gap: 0.5rem;
+  padding: 1rem 0.5rem;
+  border-radius: 12px;
+  border: 1.5px solid transparent;
+  background: var(--color-surface);
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+  cursor: default;
+
+  &:hover {
+    transform: translateY(-4px) scale(1.04);
+    border-color: var(--color-accent);
+    background: var(--color-card-hover-bg);
+    box-shadow: 0 8px 20px rgba(0, 112, 243, 0.12);
+  }
 }
 
 .img {
   object-fit: contain;
-  width: 100%;
-  max-height: 100px;
-  max-width: 200px;
-  margin: auto;
+  width: 64px;
+  height: 64px;
+  transition: filter 0.2s ease;
+}
+
+.label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  text-align: center;
+  letter-spacing: 0.03em;
+  transition: color 0.2s ease;
+
+  .cell:hover & {
+    color: var(--color-text);
+  }
 }
 
 @media (min-width: 768px) {
   .root {
-    grid-template-rows: 1fr 1fr 1fr;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-  }
-
-  .cell {
-    height: auto;
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
   }
 }

--- a/app/skills/components/skills/Skills.tsx
+++ b/app/skills/components/skills/Skills.tsx
@@ -28,7 +28,7 @@ export default function Skills(): ReactElement {
     <section className={styles.root}>
       {techs.map((tech) => (
         <div key={tech.name} className={styles.cell}>
-          <Image width={200} height={200} className={styles.img} src={tech.url} alt={tech.name} />
+          <Image width={64} height={64} className={styles.img} src={tech.url} alt={tech.name} />
           <span className={styles.label}>{tech.name}</span>
         </div>
       ))}

--- a/app/skills/components/skills/Skills.tsx
+++ b/app/skills/components/skills/Skills.tsx
@@ -1,35 +1,35 @@
 import { type ReactElement } from 'react';
 import Image from 'next/image';
-import { v4 as uuidv4 } from 'uuid';
 
 import styles from './Skills.module.css';
 
-const techs = [
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/nextjs/nextjs-original.svg',
-  'https://github.com/devicons/devicon/raw/master/icons/react/react-original.svg',
-  'https://github.com/devicons/devicon/raw/master/icons/redux/redux-original.svg',
-  'https://github.com/devicons/devicon/raw/master/icons/materialui/materialui-original.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/bootstrap/bootstrap-original.svg',
-  'https://github.com/devicons/devicon/raw/master/icons/css3/css3-plain.svg',
-  'https://github.com/devicons/devicon/raw/master/icons/html5/html5-original.svg',
-  'https://github.com/devicons/devicon/raw/master/icons/javascript/javascript-original.svg',
-  'https://github.com/devicons/devicon/raw/master/icons/typescript/typescript-original.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/webpack/webpack-plain.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/eslint/eslint-original.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-plain.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/express/express-original.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/socketio/socketio-original.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-original.svg',
-  'https://raw.githubusercontent.com/devicons/devicon/master/icons/webstorm/webstorm-plain.svg',
+const techs: { name: string; url: string }[] = [
+  { name: 'Next.js', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/nextjs/nextjs-original.svg' },
+  { name: 'React', url: 'https://github.com/devicons/devicon/raw/master/icons/react/react-original.svg' },
+  { name: 'Redux', url: 'https://github.com/devicons/devicon/raw/master/icons/redux/redux-original.svg' },
+  { name: 'Material UI', url: 'https://github.com/devicons/devicon/raw/master/icons/materialui/materialui-original.svg' },
+  { name: 'Bootstrap', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/bootstrap/bootstrap-original.svg' },
+  { name: 'CSS3', url: 'https://github.com/devicons/devicon/raw/master/icons/css3/css3-plain.svg' },
+  { name: 'HTML5', url: 'https://github.com/devicons/devicon/raw/master/icons/html5/html5-original.svg' },
+  { name: 'JavaScript', url: 'https://github.com/devicons/devicon/raw/master/icons/javascript/javascript-original.svg' },
+  { name: 'TypeScript', url: 'https://github.com/devicons/devicon/raw/master/icons/typescript/typescript-original.svg' },
+  { name: 'Webpack', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/webpack/webpack-plain.svg' },
+  { name: 'ESLint', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/eslint/eslint-original.svg' },
+  { name: 'Node.js', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-plain.svg' },
+  { name: 'Express', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/express/express-original.svg' },
+  { name: 'Socket.io', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/socketio/socketio-original.svg' },
+  { name: 'Git', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/git/git-original.svg' },
+  { name: 'Docker', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/docker/docker-original.svg' },
+  { name: 'WebStorm', url: 'https://raw.githubusercontent.com/devicons/devicon/master/icons/webstorm/webstorm-plain.svg' },
 ];
 
 export default function Skills(): ReactElement {
   return (
     <section className={styles.root}>
       {techs.map((tech) => (
-        <div key={uuidv4()} className={styles.cell}>
-          <Image width={200} height={200} className={styles.img} src={tech} alt="" />
+        <div key={tech.name} className={styles.cell}>
+          <Image width={200} height={200} className={styles.img} src={tech.url} alt={tech.name} />
+          <span className={styles.label}>{tech.name}</span>
         </div>
       ))}
     </section>

--- a/app/ui/components/footer/Footer.module.css
+++ b/app/ui/components/footer/Footer.module.css
@@ -4,9 +4,11 @@
   height: 60px;
   padding: 0 2vw;
   display: flex;
-  background: #fff;
+  background: var(--color-header-bg);
+  box-shadow: 0 -1px 0 var(--color-header-shadow);
   align-items: center;
   justify-content: space-between;
+  transition: background-color 0.3s ease;
 }
 
 .logo img {

--- a/app/ui/components/header/Header.module.css
+++ b/app/ui/components/header/Header.module.css
@@ -4,11 +4,15 @@
   height: 60px;
   padding: 0 2vw;
   display: flex;
-  background: #fff;
+  background: var(--color-header-bg);
+  box-shadow: 0 1px 0 var(--color-header-shadow);
   position: sticky;
   top: 0;
   align-items: center;
   justify-content: space-between;
+  transition: background-color 0.3s ease, box-shadow 0.3s ease;
+  z-index: 100;
+  gap: 12px;
 }
 
 .nav {
@@ -41,7 +45,7 @@
     transition: all 0.3s 0.3s;
     position: absolute;
     display: block;
-    background-color: #333;
+    background-color: var(--color-text);
     width: 100%;
     height: 3px;
     right: 0;
@@ -89,4 +93,11 @@
 
 .navLink {
   padding: 20px;
+  color: var(--color-text);
+  transition: color 0.2s;
+
+  &:hover {
+    color: var(--color-accent);
+    text-decoration: none;
+  }
 }

--- a/app/ui/components/header/Header.tsx
+++ b/app/ui/components/header/Header.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { v4 as uuidv4 } from 'uuid';
 
 import Logo from '../logo';
+import ThemeToggle from '../theme-toggle';
 
 import styles from './Header.module.css';
 
@@ -21,6 +22,7 @@ export default function Header(): ReactElement {
   return (
     <header className={styles.root}>
       <Logo />
+      <ThemeToggle />
       <button
         type="button"
         className={`${styles.toggler}${isActive ? ` ${styles.active}` : ''}`}

--- a/app/ui/components/theme-toggle/ThemeToggle.module.css
+++ b/app/ui/components/theme-toggle/ThemeToggle.module.css
@@ -1,0 +1,25 @@
+.toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border: 1.5px solid var(--color-border);
+  border-radius: 50%;
+  background: var(--color-surface);
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s, transform 0.2s;
+  flex-shrink: 0;
+
+  &:hover {
+    background: var(--color-card-hover-bg);
+    border-color: var(--color-accent);
+    transform: rotate(20deg);
+  }
+}
+
+.icon {
+  font-size: 16px;
+  line-height: 1;
+  user-select: none;
+}

--- a/app/ui/components/theme-toggle/ThemeToggle.tsx
+++ b/app/ui/components/theme-toggle/ThemeToggle.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { type ReactElement, useEffect, useState } from 'react';
+import styles from './ThemeToggle.module.css';
+
+type Theme = 'light' | 'dark';
+
+function getInitialTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  const stored = localStorage.getItem('theme') as Theme | null;
+  if (stored) return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export default function ThemeToggle(): ReactElement {
+  const [theme, setTheme] = useState<Theme>('light');
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setTheme(getInitialTheme());
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme, mounted]);
+
+  const toggle = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <button
+      type="button"
+      className={styles.toggle}
+      onClick={toggle}
+      aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+      title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+    >
+      <span className={styles.icon}>{theme === 'dark' ? '☀' : '☾'}</span>
+    </button>
+  );
+}

--- a/app/ui/components/theme-toggle/ThemeToggle.tsx
+++ b/app/ui/components/theme-toggle/ThemeToggle.tsx
@@ -13,11 +13,10 @@ function getInitialTheme(): Theme {
 }
 
 export default function ThemeToggle(): ReactElement {
-  const [theme, setTheme] = useState<Theme>('light');
+  const [theme, setTheme] = useState<Theme>(() => getInitialTheme());
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    setTheme(getInitialTheme());
     setMounted(true);
   }, []);
 

--- a/app/ui/components/theme-toggle/index.ts
+++ b/app/ui/components/theme-toggle/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ThemeToggle';

--- a/app/ui/styles/global.css
+++ b/app/ui/styles/global.css
@@ -5,6 +5,50 @@
   --fontWeight: 300;
   --fontSize: 20px;
   --letterSpacing: 0.025em;
+
+  /* Light mode tokens */
+  --color-bg: #ffffff;
+  --color-surface: #f5f5f5;
+  --color-text: #333333;
+  --color-text-muted: #666666;
+  --color-border: #e0e0e0;
+  --color-accent: #0070f3;
+  --color-accent-hover: #0051bb;
+  --color-header-bg: #ffffff;
+  --color-header-shadow: rgba(0, 0, 0, 0.08);
+  --color-card-bg: #ffffff;
+  --color-card-hover-bg: #f0f4ff;
+  --transition-theme: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+[data-theme='dark'] {
+  --color-bg: #0d0d0d;
+  --color-surface: #1a1a1a;
+  --color-text: #e8e8e8;
+  --color-text-muted: #999999;
+  --color-border: #2a2a2a;
+  --color-accent: #4da6ff;
+  --color-accent-hover: #79bcff;
+  --color-header-bg: #111111;
+  --color-header-shadow: rgba(0, 0, 0, 0.4);
+  --color-card-bg: #1a1a1a;
+  --color-card-hover-bg: #1e2a40;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --color-bg: #0d0d0d;
+    --color-surface: #1a1a1a;
+    --color-text: #e8e8e8;
+    --color-text-muted: #999999;
+    --color-border: #2a2a2a;
+    --color-accent: #4da6ff;
+    --color-accent-hover: #79bcff;
+    --color-header-bg: #111111;
+    --color-header-shadow: rgba(0, 0, 0, 0.4);
+    --color-card-bg: #1a1a1a;
+    --color-card-hover-bg: #1e2a40;
+  }
 }
 
 html {
@@ -25,6 +69,9 @@ body {
   font-family: var(--fontFamily);
   font-weight: var(--fontWeight);
   font-size: var(--fontSize);
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  transition: var(--transition-theme);
 
   --webkit-text-size-adjust: 'none';
 
@@ -45,15 +92,15 @@ body > main {
 }
 
 a {
-  color: #333;
+  color: var(--color-text);
   text-decoration: none;
 }
 
 a:hover {
-  color: #333;
+  color: var(--color-accent);
   text-decoration: underline;
 }
 
 a:visited {
-  color: #333;
+  color: var(--color-text);
 }

--- a/app/works/components/works/Works.module.css
+++ b/app/works/components/works/Works.module.css
@@ -1,26 +1,97 @@
 /* The component style is inserted here. */
 .root {
   display: grid;
-  grid-gap: 2vw;
+  grid-gap: 1.5rem;
+  align-content: start;
+}
 
-  .card {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr 1fr;
+.card {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  border-radius: 12px;
+  border: 1.5px solid var(--color-border);
+  background: var(--color-card-bg);
+  overflow: hidden;
+  text-decoration: none;
+  color: var(--color-text);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease, background 0.2s ease;
 
-    .media {
-      position: relative;
-    }
+  &:hover {
+    border-color: var(--color-accent);
+    box-shadow: 0 8px 24px rgba(0, 112, 243, 0.12);
+    transform: translateY(-2px);
+    background: var(--color-card-hover-bg);
+    text-decoration: none;
+    color: var(--color-text);
+  }
+
+  &:visited {
+    color: var(--color-text);
+  }
+}
+
+.media {
+  position: relative;
+  min-height: 100px;
+  background: var(--color-surface);
+  flex-shrink: 0;
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem 1.25rem;
+  justify-content: center;
+}
+
+.content h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-text);
+  line-height: 1.3;
+}
+
+.content p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-top: 0.25rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  border: 1px solid var(--color-border);
+  transition: background 0.2s, color 0.2s;
+
+  .card:hover & {
+    background: var(--color-accent);
+    color: #fff;
+    border-color: var(--color-accent);
   }
 }
 
 @media (min-width: 768px) {
   .root {
     grid-template-columns: 1fr 1fr;
+  }
 
-    .card {
-      grid-template-rows: auto;
-      grid-template-columns: 1fr 3fr;
-    }
+  .card {
+    grid-template-columns: 140px 1fr;
   }
 }

--- a/app/works/components/works/Works.tsx
+++ b/app/works/components/works/Works.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { v4 as uuidv4 } from 'uuid';
 
 import styles from './Works.module.css';
 import { ReactElement } from 'react';
@@ -12,28 +11,41 @@ interface TinyLinkProps {
   defaultMedia: string
 }
 
+const BLUR_PLACEHOLDER = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANsAAACkCAMAAAApKatmAAAAMFBMVEX////BwcG/v7/f39/v7+/7+/vPz8/z8/Pn5+fLy8vHx8fX19fj4+P39/fr6+vT09OFCFGdAAAC+UlEQVR4nO2a63KDIBCFVUDxEvP+b9u4BAXRpOksK+mc709lRw+cLPdpVQEAAAAAAAAAAAAAAAAAAIDvpH7BlZVnloe3TJVnloe3TJWzyXMI8QFvkkJ8wJukEB/wJinEB7xJCvEBb5JCfMCbpBAf8CYpxAe8SQrxAW+SQnzAm6QQHwU2CQAAAAAAALCiJ6Wm7jisk3BnlVLaSDTs9+jmgdpHjaobYlCH4VpFNuzgws14y93eTzj01j0tLPRbc7shCG8pNe0Wrmehdv+GI2+htUdzzeuw6cNwU5C5A2+GPAyT1q4Lts+wy9qorBqCcNW6Tqr1ROG6nG554O1OFujR5cTSsyLH1BXNuIUt9VCXRArfxdr+jtSbDpPSkaHlibJZ+1HWryaGMFeUuXRyvYjU2xiNmrsvTdGL81JaHuyW5KR0Nak3ys9aWltLw2qb+VtlaZUj7+t6Z9Y0l0DirQu7ZFXdaDg9HvzfHbVPoIPGZymzSeLN7gKNa3x3Mk3sLMdpvJjEm9oFetcXj/cv8cTjv57yNfcj3nprXSaC95RHn3hLf4Jr+IM3vwNZiv/Am/nIW7F9cn4xl7RbxL/1VXPJbg0w4RrgVi694D/brQFt0WvAbu2mNC5rd7xyGf/ZLlFN9PHFvNtzraV4z7Wugt+159LhENr2yrRB8Yc2d96hz+ogn6b0vbIbM+7Hd8dRd5ihDLrDjLmvc4mbGZ/hfjdrXoxuIpaGdf5sOo9N0NgbhevRWn9r4n4SMrScTV24tLNp7M2NmpXeb/6jcDt4b/FVQzELQHXsrbLhXdB2rrFhdFq7cnhFVBcz2KoTb9VtfJYHG77c+RstZZZVwA/Ts6u9UjH6sRm2SRZu8yM8pw5OrmQBAAAAAAAA0hT4j8/4P3NJIT7gTVKID3iTFOID3iSF+IA3SSE+4E1SiA94kxTiA94khfiAN0khPuBNUogPeJMU4oPX2wkc+n+tPLM8vGWqPLM8vGWqPHvdAAAAAAAAAAAAAAAAAAD4An4A5QcTnXnPO7wAAAAASUVORK5CYII=';
+
+function parseBadges(description: string): string[] {
+  return description.split(',').map((s) => s.trim()).filter(Boolean);
+}
+
 export default function Works({ links }: { links: TinyLinkProps[] }): ReactElement {
   return (
     <div className={styles.root}>
-      {links && links.map((link) => (
-        <Link key={uuidv4()} href={link.url} passHref className={styles.card} target="_blank" rel="noopener noreferrer">
-        <span className={styles.media}>
-          {link.defaultMedia && (
-            <Image
-              fill
-              alt={link.header}
-              src={link.defaultMedia}
-              blurDataURL={`${'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAANsAAACkCAMAAAApKatmAAAAMFBMVEX////BwcG/v7/f39/v7+/7+/vPz8/z8/Pn5+fLy8vHx8fX19fj4+P39/fr6+vT09OFCFGdAAAC+UlEQVR4nO2a63KDIBCFVUDxEvP+b9u4BAXRpOksK+mc709lRw+cLPdpVQEAAAAAAAAAAAAAAAAAAIDvpH7BlZVnloe3TJVnloe3TJWzyXMI8QFvkkJ8wJukEB/wJinEB7xJCvEBb5JCfMCbpBAf8CYpxAe8SQrxAW+SQnzAm6QQHwU2CQAAAAAAALCiJ6Wm7jisk3BnlVLaSDTs9+jmgdpHjaobYlCH4VpFNuzgws14y93eTzj01j0tLPRbc7shCG8pNe0Wrmehdv+GI2+htUdzzeuw6cNwU5C5A2+GPAyT1q4Lts+wy9qorBqCcNW6Tqr1ROG6nG554O1OFujR5cTSsyLH1BXNuIUt9VCXRArfxdr+jtSbDpPSkaHlibJZ+1HWryaGMFeUuXRyvYjU2xiNmrsvTdGL81JaHuyW5KR0Nak3ys9aWltLw2qb+VtlaZUj7+t6Z9Y0l0DirQu7ZFXdaDg9HvzfHbVPoIPGZymzSeLN7gKNa3x3Mk3sLMdpvJjEm9oFetcXj/cv8cTjv57yNfcj3nprXSaC95RHn3hLf4Jr+IM3vwNZiv/Am/nIW7F9cn4xl7RbxL/1VXPJbg0w4RrgVi694D/brQFt0WvAbu2mNC5rd7xyGf/ZLlFN9PHFvNtzraV4z7Wugt+159LhENr2yrRB8Yc2d96hz+ogn6b0vbIbM+7Hd8dRd5ihDLrDjLmvc4mbGZ/hfjdrXoxuIpaGdf5sOo9N0NgbhevRWn9r4n4SMrScTV24tLNp7M2NmpXeb/6jcDt4b/FVQzELQHXsrbLhXdB2rrFhdFq7cnhFVBcz2KoTb9VtfJYHG77c+RstZZZVwA/Ts6u9UjH6sRm2SRZu8yM8pw5OrmQBAAAAAAAA0hT4j8/4P3NJIT7gTVKID3iTFOID3iSF+IA3SSE+4E1SiA94kxTiA94khfiAN0khPuBNUogPeJMU4oPX2wkc+n+tPLM8vGWqPLM8vGWqPHvdAAAAAAAAAAAAAAAAAAD4An4A5QcTnXnPO7wAAAAASUVORK5CYII='}`}
-            />
-          )}
-        </span>
-          <span className="content">
-          <h4>{link.header}</h4>
-          <p>{link.description}</p>
-        </span>
-        </Link>
-        // <LinkPreview key={uuidv4()} url={link.url} render={CustomComponent} />
-      ))}
+      {links && links.map((link) => {
+        const badges = parseBadges(link.description);
+        return (
+          <Link key={link.url} href={link.url} passHref className={styles.card} target="_blank" rel="noopener noreferrer">
+            <span className={styles.media}>
+              {link.defaultMedia && (
+                <Image
+                  fill
+                  alt={link.header}
+                  src={link.defaultMedia}
+                  blurDataURL={BLUR_PLACEHOLDER}
+                  style={{ objectFit: 'contain', padding: '12px' }}
+                />
+              )}
+            </span>
+            <span className={styles.content}>
+              <h4>{link.header}</h4>
+              <div className={styles.badges}>
+                {badges.map((badge) => (
+                  <span key={badge} className={styles.badge}>{badge}</span>
+                ))}
+              </div>
+            </span>
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/app/works/components/works/Works.tsx
+++ b/app/works/components/works/Works.tsx
@@ -38,8 +38,8 @@ export default function Works({ links }: { links: TinyLinkProps[] }): ReactEleme
             <span className={styles.content}>
               <h4>{link.header}</h4>
               <div className={styles.badges}>
-                {badges.map((badge) => (
-                  <span key={badge} className={styles.badge}>{badge}</span>
+                {badges.map((badge, index) => (
+                  <span key={`${link.url}-${badge}-${index}`} className={styles.badge}>{badge}</span>
                 ))}
               </div>
             </span>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
- Add dark/light mode toggle with CSS custom properties for full theme support
  (respects prefers-color-scheme, persists to localStorage, toggleable via header button)
- Add tech stack name labels below icons on Skills page with hover scale + border animations
- Use stable keys (tech name / URL) instead of uuidv4() on every render for Skills/Works
- Add animated tagline ("crafting with React · TypeScript · Next.js · Node.js") on Home page
  with staggered fade-slide-in keyframe animation
- Fix tagline stagger visibility bug by preventing parent opacity fade from masking child tag animations,
  and offset child animation delays to start after the tagline intro delay
- Redesign Works cards: side-by-side image + content layout, tech stack badge chips
  that highlight on card hover, smooth lift + accent-border hover effect
- Update header/footer/nav to use CSS theme variables (bg, text, border, shadow)
- Add accent color link hover on About page

https://claude.ai/code/session_01JVfKiSuqHjKzdMC6SPx6RJ
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ce761d6-07c4-40b7-8500-94339089195d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ce761d6-07c4-40b7-8500-94339089195d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

